### PR TITLE
Add CI/CD workflows and preprod checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+      - name: Build Docker image
+        run: docker build . -t app:ci

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to Railway
+        uses: railwayapp/railway-action@v1
+        with:
+          railwayToken: ${{ secrets.RAILWAY_TOKEN }}
+          projectId: ${{ secrets.RAILWAY_PROJECT_ID }}
+          command: up

--- a/CHECKLIST_preprod.md
+++ b/CHECKLIST_preprod.md
@@ -1,0 +1,8 @@
+# Checklist pré-production
+
+- [ ] APP_ENV défini
+- [ ] FLASK_ENV défini
+- [ ] PORT assigné
+- [ ] TZ défini
+- [ ] SECRET_KEY défini
+- [ ] DATABASE_URL défini

--- a/README_quickstart.md
+++ b/README_quickstart.md
@@ -54,3 +54,10 @@ gunicorn -b 0.0.0.0:8000 "app:create_app()"
 # or for quick dev:
 # flask --app app.py run -p 8000
 ```
+
+## CI/CD
+
+- `.github/workflows/ci.yml` configure Python 3.11, installe les dépendances, lance `pytest` puis construit l'image Docker.
+- `.github/workflows/deploy-railway.yml` déploie sur Railway à chaque `push` sur `main` en utilisant les secrets `RAILWAY_TOKEN` et `RAILWAY_PROJECT_ID`.
+
+Les variables d'environnement Railway suivantes doivent être définies avant déploiement : `APP_ENV`, `FLASK_ENV`, `PORT`, `TZ`, `SECRET_KEY`, `DATABASE_URL`. Consultez `CHECKLIST_preprod.md` pour la liste de vérifications pré-production.


### PR DESCRIPTION
## Summary
- add CI workflow running tests on Python 3.11 and building Docker image
- add Railway deploy workflow triggered on pushes to main
- document CI/CD and required env vars with pre-production checklist

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c5824c9660832c954948a69ccad47a