### PR TITLE
Add user management and legal pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest
+      - name: Build Docker image
+        run: docker build -f docker/Dockerfile . -t app:ci

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to Railway
+        uses: railwayapp/railway-action@v1
+        with:
+          railwayToken: ${{ secrets.RAILWAY_TOKEN }}
+          projectId: ${{ secrets.RAILWAY_PROJECT_ID }}
+          command: up

--- a/CHECKLIST_preprod.md
+++ b/CHECKLIST_preprod.md
@@ -1,0 +1,8 @@
+# Checklist pré-production
+
+- [ ] APP_ENV défini
+- [ ] FLASK_ENV défini
+- [ ] PORT assigné
+- [ ] TZ défini
+- [ ] SECRET_KEY défini
+- [ ] DATABASE_URL défini

--- a/README_quickstart.md
+++ b/README_quickstart.md
@@ -54,3 +54,10 @@ gunicorn -b 0.0.0.0:8000 "app:create_app()"
 # or for quick dev:
 # flask --app app.py run -p 8000
 ```
+
+## CI/CD
+
+- `.github/workflows/ci.yml` configure Python 3.11, installe les dépendances, lance `pytest` puis construit l'image Docker.
+- `.github/workflows/deploy-railway.yml` déploie sur Railway à chaque `push` sur `main` en utilisant les secrets `RAILWAY_TOKEN` et `RAILWAY_PROJECT_ID`.
+
+Les variables d'environnement Railway suivantes doivent être définies avant déploiement : `APP_ENV`, `FLASK_ENV`, `PORT`, `TZ`, `SECRET_KEY`, `DATABASE_URL`. Consultez `CHECKLIST_preprod.md` pour la liste de vérifications pré-production.

--- a/app.py
+++ b/app.py
@@ -77,6 +77,7 @@ from controllers.admin_controller import admin_bp  # noqa: E402
 from controllers.cart_controller import cart_bp  # noqa: E402
 from controllers.payement_controller import payement_bp  # noqa: E402
 from controllers.account_controller import account_bp  # noqa: E402
+from controllers.pages_controller import pages_bp  # noqa: E402
 
 # ✅ Ton blueprint “story”
 from controllers.generateur_controller import bp as story_bp  # noqa: E402
@@ -151,13 +152,14 @@ def create_app() -> Flask:
             return None
 
     # ---- Blueprints applicatifs
-    app.register_blueprint(register_bp, url_prefix="/register")
+    app.register_blueprint(register_bp)
     app.register_blueprint(login_bp, url_prefix="/auth")
     app.register_blueprint(admin_bp)   # sans url_prefix (déjà dans le BP)
     app.register_blueprint(cart_bp, url_prefix="/cart")
     app.register_blueprint(payement_bp, url_prefix="/payement")
     app.register_blueprint(account_bp, url_prefix="/account")
     app.register_blueprint(story_bp)  # possède déjà son url_prefix
+    app.register_blueprint(pages_bp)
 
     # Webhook Stripe (facultatif)
     try:

--- a/controllers/account_controller.py
+++ b/controllers/account_controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from flask import Blueprint, render_template, redirect, url_for, flash
 from flask_login import login_required, current_user
 
+from models import db
 from models.user_model import User
 from models.order_model import Order
 
@@ -52,3 +53,14 @@ def order_details(order_id: int):
         return redirect(url_for("account_bp.user_dashboard"))
 
     return render_template("order_details.html", order=order)
+
+@account_bp.route('/password', methods=['GET', 'POST'])
+@login_required
+def change_password():
+    user: User = current_user  # type: ignore
+    if request.method == 'POST':
+        user.set_password(request.form['new_password'])
+        db.session.commit()
+        flash('Mot de passe mis à jour.', 'success')
+        return redirect(url_for('account_bp.user_dashboard'))
+    return render_template('change_password.html')

--- a/controllers/admin_controller.py
+++ b/controllers/admin_controller.py
@@ -8,6 +8,7 @@ from models import db
 from models.book_model import Book
 from models.author_model import Author
 from models.category_model import Category
+from models.user_model import User
 
 admin_bp = Blueprint('admin_bp', __name__, url_prefix='/admin')
 
@@ -199,3 +200,61 @@ def delete_category(category_id):
     db.session.commit()
     flash("Catégorie supprimée.", "success")
     return redirect(url_for('admin_bp.list_categories'))
+
+# ------- Users -------
+@admin_bp.route('/users', methods=['GET'])
+@admin_required
+def list_users():
+    users = User.query.all()
+    return render_template('manage_users.html', users=users)
+
+@admin_bp.route('/users/add', methods=['GET', 'POST'])
+@admin_required
+def add_user():
+    if request.method == 'POST':
+        u = User(
+            user_firstname=request.form['user_firstname'],
+            user_lastname=request.form['user_lastname'],
+            user_email=request.form['user_email'],
+            user_role=request.form.get('user_role', 'user')
+        )
+        u.set_password(request.form['user_password'])
+        db.session.add(u)
+        db.session.commit()
+        flash("Utilisateur ajouté.", "success")
+        return redirect(url_for('admin_bp.list_users'))
+    return render_template('add_user.html')
+
+@admin_bp.route('/users/<int:user_id>/edit', methods=['GET', 'POST'])
+@admin_required
+def edit_user(user_id):
+    user = User.query.get_or_404(user_id)
+    if request.method == 'POST':
+        user.user_firstname = request.form['user_firstname']
+        user.user_lastname = request.form['user_lastname']
+        user.user_email = request.form['user_email']
+        user.user_role = request.form.get('user_role', 'user')
+        db.session.commit()
+        flash("Utilisateur modifié.", "success")
+        return redirect(url_for('admin_bp.list_users'))
+    return render_template('edit_user.html', user=user)
+
+@admin_bp.route('/users/<int:user_id>/password', methods=['GET', 'POST'])
+@admin_required
+def change_user_password(user_id):
+    user = User.query.get_or_404(user_id)
+    if request.method == 'POST':
+        user.set_password(request.form['user_password'])
+        db.session.commit()
+        flash("Mot de passe mis à jour.", "success")
+        return redirect(url_for('admin_bp.list_users'))
+    return render_template('change_user_password.html', user=user)
+
+@admin_bp.route('/users/<int:user_id>/delete', methods=['POST'])
+@admin_required
+def delete_user(user_id):
+    user = User.query.get_or_404(user_id)
+    db.session.delete(user)
+    db.session.commit()
+    flash("Utilisateur supprimé.", "success")
+    return redirect(url_for('admin_bp.list_users'))

--- a/controllers/pages_controller.py
+++ b/controllers/pages_controller.py
@@ -1,0 +1,25 @@
+from flask import Blueprint, render_template
+
+pages_bp = Blueprint('pages_bp', __name__)
+
+@pages_bp.route('/privacy')
+def privacy():
+    return render_template('privacy.html')
+
+@pages_bp.route('/terms')
+def terms():
+    return render_template('terms.html')
+
+@pages_bp.route('/contact')
+def contact():
+    return render_template('contact.html')
+
+
+@pages_bp.route('/cookies')
+def cookies():
+    return render_template('cookies.html')
+
+
+@pages_bp.route('/cgv')
+def cgv():
+    return render_template('cgv.html')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/static/css/crud.css
+++ b/static/css/crud.css
@@ -118,3 +118,48 @@ button.btn-delete:hover {
         padding: 8px 12px;
     }
 }
+
+/* --- Formulaires CRUD --- */
+form.crud-form {
+    width: 90%;
+    margin: 20px auto;
+    background: #fff;
+    padding: 20px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+}
+
+form.crud-form label {
+    display: block;
+    margin-top: 10px;
+    font-weight: 600;
+}
+
+form.crud-form input,
+form.crud-form select {
+    width: 100%;
+    padding: 8px;
+    margin-top: 4px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+form.crud-form input[type="submit"],
+form.crud-form button {
+    margin-top: 15px;
+    background-color: #093163;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+a.btn-back {
+    display: inline-block;
+    margin: 20px;
+    text-decoration: none;
+    color: #093163;
+}
+
+a.btn-back:hover {
+    text-decoration: underline;
+}

--- a/static/js/generator/flipbook.js
+++ b/static/js/generator/flipbook.js
@@ -21,7 +21,8 @@ function buildBook(storyText) {
   
     addPage(book, 'Couverture', 'cover');          // page 0   (gauche)
     chapters.forEach(ch => addPage(book, ch));     // pages 1..n
-    const morale = chapters.at(-1).split('\n').pop();
+    const lastChapter = chapters[chapters.length - 1] || '';
+    const morale = lastChapter.split('\n').pop();
     addPage(book, 'Morale :<br>' + morale, 'morale'); // dernière
   
     const pages = [...book.querySelectorAll('.page')];

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     bars.forEach((bar, idx) => {
       bar.style.background = idx < score ? getStrengthColor(score) : '#e2e8f0';
     });
-    const labels = ['Très faible','Faible','Moyen','Fort','Fort'];
+    const labels = ['Très faible','Faible','Moyen','Moyen','Fort'];
     label.textContent = labels[Math.min(4, score || 0)];
     label.style.color = getStrengthColor(score);
   }
@@ -105,8 +105,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function getStrengthColor(score) {
-    const colors = ['#e53e3e', '#dd6b20', '#d69e2e', '#38a169'];
-    return colors[(score || 1) - 1] || '#e2e8f0';
+    if (score >= 4) return '#38a169'; // fort
+    if (score >= 2) return '#ecc94b'; // moyen
+    return '#e53e3e'; // faible
   }
 
   // Écoutes

--- a/templates/add_user.html
+++ b/templates/add_user.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block title %}Ajouter un utilisateur{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/crud.css') }}">
+{% endblock %}
+
+{% block content %}
+<a href="{{ url_for('admin_bp.manage_users') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
+<h1>Ajouter un utilisateur</h1>
+<form method="post" class="crud-form">
+  <label for="user_firstname">Prénom</label>
+  <input id="user_firstname" name="user_firstname" required>
+
+  <label for="user_lastname">Nom</label>
+  <input id="user_lastname" name="user_lastname" required>
+
+  <label for="user_email">Email</label>
+  <input id="user_email" name="user_email" type="email" required>
+
+  <label for="user_role">Rôle</label>
+  <input id="user_role" name="user_role" value="user">
+
+  <label for="user_password">Mot de passe</label>
+  <input id="user_password" name="user_password" type="password" required>
+
+  <button type="submit">Créer</button>
+</form>
+{% endblock %}

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -31,6 +31,12 @@
                     <h2>Gérer les Auteurs</h2>
                 </a>
             </div>
+            <div class="dashboard-item">
+                <a href="{{ url_for('admin_bp.list_users') }}">
+                    <img src="{{ url_for('static', filename='icons/authors_icon.png') }}" alt="Users Icon">
+                    <h2>Gérer les Utilisateurs</h2>
+                </a>
+            </div>
             
         </div>
     </main>

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,14 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/cart.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/home.css') }}">
     {% block extra_css %}{% endblock %}
+    <style>
+    .flash-messages{max-width:600px;margin:1rem auto;padding:0 1rem;}
+    .alert{padding:.75rem 1rem;border-radius:.375rem;margin-bottom:.5rem;}
+    .alert-success{background:#f0fff4;color:#38a169;}
+    .alert-danger{background:#fff5f5;color:#e53e3e;}
+    .alert-warning{background:#fffaf0;color:#d69e2e;}
+    .alert-info{background:#ebf8ff;color:#3182ce;}
+    </style>
 </head>
 <body>
 
@@ -90,7 +98,7 @@
                         </ul>
                     </li>
 
-                    <li><a href="#" class="nav__link">Contact</a></li>
+                    <li><a href="{{ url_for('pages_bp.contact') }}" class="nav__link">Contact</a></li>
                     {% if current_user.is_authenticated and ((current_user.user_role or '')|lower == 'admin' or current_user.is_admin) %}
                     <li><a href="{{ url_for('admin_bp.dashboard') }}" class="nav__link">Admin</a></li>
                     {% endif %}
@@ -145,6 +153,15 @@
 
     <!-- Section principale -->
     <main class="content">
+        {% with messages = get_flashed_messages(with_categories=True) %}
+            {% if messages %}
+                <div class="flash-messages">
+                    {% for category, message in messages %}
+                        <div class="alert alert-{{ category }}">{{ message }}</div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        {% endwith %}
         {% block content %}{% endblock %}
     </main>
 
@@ -161,11 +178,11 @@
             <!-- Menu -->
             <nav class="footer-nav">
                 <ul class="footer-menu">
-                    <li><a href="#">RGPD</a></li>
-                    <li><a href="#">CGU</a></li>
-                    <li><a href="#">CGV</a></li>
-                    <li><a href="#">Cookies</a></li>
-                    <li><a href="#">Contact</a></li>
+                    <li><a href="{{ url_for('pages_bp.privacy') }}">RGPD</a></li>
+                    <li><a href="{{ url_for('pages_bp.terms') }}">CGU</a></li>
+                    <li><a href="{{ url_for('pages_bp.cgv') }}">CGV</a></li>
+                    <li><a href="{{ url_for('pages_bp.cookies') }}">Cookies</a></li>
+                    <li><a href="{{ url_for('pages_bp.contact') }}">Contact</a></li>
                 </ul>
             </nav>
 

--- a/templates/cgv.html
+++ b/templates/cgv.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}CGV{% endblock %}
+{% block extra_css %}<link rel="stylesheet" href="{{ url_for('static', filename='css/crud.css') }}">{% endblock %}
+{% block content %}
+<a href="{{ url_for('home') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
+<h1>Conditions Générales de Vente</h1>
+<p>Les présentes conditions encadrent les ventes réalisées sur le site.</p>
+{% endblock %}

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Changer mon mot de passe{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/crud.css') }}">
+{% endblock %}
+
+{% block content %}
+<a href="{{ url_for('account_bp.user_dashboard') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
+<h1>Changer mon mot de passe</h1>
+<form method="post" class="crud-form">
+  <label for="new_password">Nouveau mot de passe</label>
+  <input id="new_password" name="new_password" type="password" required>
+
+  <button type="submit">Enregistrer</button>
+</form>
+{% endblock %}

--- a/templates/change_user_password.html
+++ b/templates/change_user_password.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Changer le mot de passe{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/crud.css') }}">
+{% endblock %}
+
+{% block content %}
+<a href="{{ url_for('admin_bp.manage_users') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
+<h1>Changer le mot de passe</h1>
+<form method="post" class="crud-form">
+  <label for="user_password">Nouveau mot de passe</label>
+  <input id="user_password" name="user_password" type="password" required>
+
+  <button type="submit">Mettre à jour</button>
+</form>
+{% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Contact{% endblock %}
+{% block content %}
+<h1>Contact</h1>
+<p>Utilisez ce formulaire pour nous contacter.</p>
+{% endblock %}

--- a/templates/cookies.html
+++ b/templates/cookies.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}Cookies{% endblock %}
+{% block extra_css %}<link rel="stylesheet" href="{{ url_for('static', filename='css/crud.css') }}">{% endblock %}
+{% block content %}
+<a href="{{ url_for('home') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
+<h1>Politique de cookies</h1>
+<p>Cette page décrit l'utilisation des cookies sur notre site.</p>
+{% endblock %}

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block title %}Modifier un utilisateur{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/crud.css') }}">
+{% endblock %}
+
+{% block content %}
+<a href="{{ url_for('admin_bp.manage_users') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
+<h1>Modifier un utilisateur</h1>
+<form method="post" class="crud-form">
+  <label for="user_firstname">Prénom</label>
+  <input id="user_firstname" name="user_firstname" value="{{ user.user_firstname }}" required>
+
+  <label for="user_lastname">Nom</label>
+  <input id="user_lastname" name="user_lastname" value="{{ user.user_lastname }}" required>
+
+  <label for="user_email">Email</label>
+  <input id="user_email" name="user_email" type="email" value="{{ user.user_email }}" required>
+
+  <label for="user_role">Rôle</label>
+  <input id="user_role" name="user_role" value="{{ user.user_role }}">
+
+  <button type="submit">Enregistrer</button>
+</form>
+{% endblock %}

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -25,12 +25,11 @@
     {% if messages %}
     <div class="message-box">
       {% for category, message in messages %}
-      <div class="alert alert-{{ category }}">{{ message }}</div>
+      <div id="welcome" class="alert alert-{{ category }}">{{ message }}</div>
       {% endfor %}
     </div>
     {% endif %}
     {% endwith %}
-
     <div class="filter-group">
       <h3 class="filter-title">
         <i class="fa fa-filter"></i> Catégories

--- a/templates/generator/generateur.html
+++ b/templates/generator/generateur.html
@@ -50,6 +50,9 @@
     button { cursor: pointer; background:#111827; color:#fff; border:none; }
     button:hover { filter: brightness(1.05); }
     .mic-btn img { vertical-align: middle; }
+    .mic-btn { background:none; border:none; padding:0; }
+    .btn-back { display:inline-block;margin-bottom:16px;color:#093163;text-decoration:none; }
+    .btn-back:hover { text-decoration:underline; }
 
     /* Zone d’affichage de l’histoire + flipbook centrés */
     #story-container {
@@ -80,37 +83,38 @@
 </head>
 <body>
   <div class="container">
+    <a href="{{ url_for('home') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
     <h1>Conte animalier personnalisé</h1>
 
     <form id="story-form">
       <label>Âge cible
         <input type="number" id="age" value="6" min="3" max="10" />
-        <span class="mic-btn" data-target="age"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="microphone"/></span>
+        <button type="button" class="mic-btn" data-target="age" aria-label="Dicter l'âge"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="Micro"></button>
       </label>
       <label>Nom du héros
         <input type="text" id="name" value="Axelle" />
-        <span class="mic-btn" data-target="name"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="microphone"/></span>
+        <button type="button" class="mic-btn" data-target="name" aria-label="Dicter le nom"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="Micro"></button>
       </label>
       <label>Genre
         <input type="text" id="genre" value="Conte animalier" />
-        <span class="mic-btn" data-target="genre"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="microphone"/></span>
+        <button type="button" class="mic-btn" data-target="genre" aria-label="Dicter le genre"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="Micro"></button>
       </label>
       <label>Éléments clés
         <input type="text" id="elements" value="animaux qui parlent, rimes, comptine répétitive" />
-        <span class="mic-btn" data-target="elements"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="microphone"/></span>
+        <button type="button" class="mic-btn" data-target="elements" aria-label="Dicter les éléments"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="Micro"></button>
       </label>
       <label>Thèmes
         <input type="text" id="themes" value="confiance en soi, entraide" />
-        <span class="mic-btn" data-target="themes"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="microphone"/></span>
+        <button type="button" class="mic-btn" data-target="themes" aria-label="Dicter les thèmes"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="Micro"></button>
       </label>
       <label>Ton souhaité
         <input type="text" id="tone" value="joyeux et rassurant" />
-        <span class="mic-btn" data-target="tone"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="microphone"/></span>
+        <button type="button" class="mic-btn" data-target="tone" aria-label="Dicter le ton"><img width="24" height="24" src="https://img.icons8.com/fluency-systems-filled/48/microphone.png" alt="Micro"></button>
       </label>
       <button type="submit">Générer l'histoire</button>
     </form>
 
-    <div id="story-container"></div>
+    <div id="story-container" aria-live="polite"></div>
   </div>
 
   <!-- flipbook + speech -->

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,18 +12,6 @@
           <p>Connectez-vous pour accéder à votre compte</p>
         </div>
 
-        {% with messages = get_flashed_messages(with_categories=True) %}
-          {% if messages %}
-            <div class="flash-messages">
-              {% for category, message in messages %}
-                <div class="alert alert-{{ category }}">
-                  {{ message }}
-                </div>
-              {% endfor %}
-            </div>
-          {% endif %}
-        {% endwith %}
-
         <form method="POST" action="{{ url_for('login_bp.login') }}" class="auth-form">
           <div class="form-group">
             <label for="user_email">Email</label>

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block title %}Gestion des utilisateurs{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/crud.css') }}">
+{% endblock %}
+
+{% block content %}
+<a href="{{ url_for('admin_bp.dashboard') }}" class="btn-back" aria-label="Retour">&larr; Retour</a>
+<header>
+  <h1>Gestion des utilisateurs</h1>
+  <a href="{{ url_for('admin_bp.add_user') }}" class="btn btn-add" aria-label="Ajouter un utilisateur">Ajouter un utilisateur</a>
+</header>
+
+<table>
+  <thead>
+    <tr><th>Prénom</th><th>Nom</th><th>Email</th><th>Rôle</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  {% for u in users %}
+    <tr>
+      <td>{{ u.user_firstname }}</td>
+      <td>{{ u.user_lastname }}</td>
+      <td>{{ u.user_email }}</td>
+      <td>{{ u.user_role }}</td>
+      <td>
+        <a href="{{ url_for('admin_bp.edit_user', user_id=u.user_id) }}" class="btn btn-edit" aria-label="Modifier {{ u.user_firstname }}">Modifier</a>
+        <a href="{{ url_for('admin_bp.change_user_password', user_id=u.user_id) }}" class="btn btn-edit" aria-label="Changer le mot de passe de {{ u.user_firstname }}">Mot de passe</a>
+        <form action="{{ url_for('admin_bp.delete_user', user_id=u.user_id) }}" method="post" style="display:inline;" onsubmit="return confirm('Supprimer cet utilisateur ?');">
+          <button type="submit" class="btn btn-delete" aria-label="Supprimer {{ u.user_firstname }}">Supprimer</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Politique de confidentialité{% endblock %}
+{% block content %}
+<h1>Politique de confidentialité</h1>
+<p>Votre vie privée est importante pour nous.</p>
+{% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Conditions d'utilisation{% endblock %}
+{% block content %}
+<h1>Conditions générales d'utilisation</h1>
+<p>Voici nos conditions d'utilisation.</p>
+{% endblock %}

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+os.environ.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite://")
+
+from app import create_app
+from models import db, User
+
+class TestLoginWelcome(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app()
+        self.app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+        self.client = self.app.test_client()
+        with self.app.app_context():
+            db.create_all()
+            u = User(
+                user_firstname="John",
+                user_lastname="Doe",
+                user_email="john@example.com",
+            )
+            u.set_password("Securepassword123!")
+            db.session.add(u)
+            db.session.commit()
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_login_welcome_message(self):
+        resp = self.client.post(
+            "/auth/login",
+            data={"user_email": "john@example.com", "user_password": "Securepassword123!"},
+            follow_redirects=True,
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_data(as_text=True)
+        self.assertIn("Bienvenue John !", body)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- style admin user tables and forms with CRUD CSS and add deletion confirmation
- include cookies and CGV routes and link them in the footer
- improve story generator accessibility with voice input, back links and reliable flipbook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5824c9660832c954948a69ccad47a