### PR TITLE
docs: add optional service env vars to preprod checklist

### DIFF
--- a/CHECKLIST_preprod.md
+++ b/CHECKLIST_preprod.md
@@ -6,3 +6,14 @@
 - [ ] TZ défini
 - [ ] SECRET_KEY défini
 - [ ] DATABASE_URL défini
+- [ ] STRIPE_SECRET_KEY défini (si Stripe est activé)
+- [ ] STRIPE_PUBLIC_KEY défini (si Stripe est activé)
+- [ ] STRIPE_WEBHOOK_SECRET défini (si Stripe est activé)
+- [ ] MONGODB_URI défini (si MongoDB est activé)
+- [ ] MAIL_SERVER défini (si service mail est activé)
+- [ ] MAIL_PORT défini (si service mail est activé)
+- [ ] MAIL_USE_TLS défini (si service mail est activé)
+- [ ] MAIL_USE_SSL défini (si service mail est activé)
+- [ ] MAIL_USERNAME défini (si service mail est activé)
+- [ ] MAIL_PASSWORD défini (si service mail est activé)
+- [ ] MAIL_DEFAULT_SENDER défini (si service mail est activé)


### PR DESCRIPTION
## Summary
- note Stripe keys, MongoDB URI, and mail settings in preprod checklist when services are enabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c680909804832cbad55981763dc96c