### PR TITLE
Use MONGODB_URI consistently

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,7 +107,7 @@ def create_app() -> Flask:
 
     # Mongo optionnel
     try:
-        mongo_uri = os.getenv("MONGODB_URI") or os.getenv("MONGO_URI")
+        mongo_uri = os.getenv("MONGODB_URI")
         if mongo_uri:
             app.config["MONGODB_URI"] = mongo_uri
             from extensions import init_mongo  # type: ignore


### PR DESCRIPTION
## Summary
- reference only `MONGODB_URI` for optional Mongo connection
- ensure no legacy `MONGO_URI` usages remain

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6a219d3fc832c88ff68f58eaedd5b