### PR TITLE
Enforce DATABASE_URL when APP_ENV=production

### DIFF
--- a/CHECKLIST_preprod.md
+++ b/CHECKLIST_preprod.md
@@ -5,7 +5,7 @@
 - [ ] PORT assigné
 - [ ] TZ défini
 - [ ] SECRET_KEY défini
-- [ ] DATABASE_URL défini
+- [ ] DATABASE_URL défini (obligatoire si APP_ENV=production)
 - [ ] STRIPE_SECRET_KEY défini (si Stripe est activé)
 - [ ] STRIPE_PUBLIC_KEY défini (si Stripe est activé)
 - [ ] STRIPE_WEBHOOK_SECRET défini (si Stripe est activé)

--- a/README_quickstart.md
+++ b/README_quickstart.md
@@ -12,6 +12,7 @@ This bundle helps you run your Flask app (with `create_app()` in `app.py` at the
    - `SECRET_KEY` — put any random string.
    - Keep `POSTGRES_*` as-is unless you want to change them.
 2. Ensure your app factory exists: `app.py` exposes `create_app()`.
+3. If you run with `APP_ENV=production`, define `DATABASE_URL` or the container will exit.
 
 ## 3) Run
 ```bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+# Refuser de démarrer si APP_ENV=production sans DATABASE_URL explicite
+if [ "${APP_ENV}" = "production" ] && [ -z "${DATABASE_URL}" ]; then
+  echo "ERROR: DATABASE_URL must be set when APP_ENV=production" >&2
+  exit 1
+fi
+
 # Si DATABASE_URL est fournie (prod/ci), attendre via cette URL
 if [ -n "${DATABASE_URL}" ]; then
   echo "Waiting for database via DATABASE_URL ..."


### PR DESCRIPTION
## Summary
- fail fast in entrypoint when running in production without DATABASE_URL
- document the requirement in quickstart and preprod checklist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6a227b23c832cbe46a75d57337b22