### PR TITLE
docs: close docker quickstart code block

### DIFF
--- a/README_quickstart.md
+++ b/README_quickstart.md
@@ -18,3 +18,4 @@ This bundle helps you run your Flask app (with `create_app()` in `app.py` at the
 ## 3) Run
 ```bash
 docker compose up --build
+```


### PR DESCRIPTION
## Summary
- close code block in README_quickstart to fix rendering

## Testing
- `python -m markdown README_quickstart.md` *(fails: No module named markdown)*
- `pip install markdown` *(fails: Could not find a version)
- `python -m rich.markdown README_quickstart.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6dbd89bf8832ca3b6d26dac96e0a2